### PR TITLE
Test fix + Instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 /*.tgz
 /*.log
 *.js
+
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
      require dogescript
           such node
-        wow 
+        wow
 
 # Todo
 
@@ -27,6 +27,18 @@ require('require-doge');
 
 var amaze = require('./doge.djs');
 ````
+
+Check loaded extension:
+
+```bash
+$ node
+> require('./index.js')
+> require.extensions
+{ '.js': [Function],
+  '.json': [Function],
+  '.node': [Function],
+  '.djs': [Function: compile] }
+```
 
 ## History
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "require-doge",
   "description": "much require dogescript, such node",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "homepage": "https://github.com/dogescript/require-doge",
   "author": {
     "name": "Bart van der Schoor",
@@ -39,5 +39,6 @@
     "dogescript": "~2.3.0"
   },
   "devDependencies": {
+    "tape": "^4.9.1"
   }
 }

--- a/test/fixtures/doge.djs
+++ b/test/fixtures/doge.djs
@@ -1,5 +1,5 @@
 such loge
-    plz console.loge 'wow!'
+    plz console.loge with 'wow!'
 wow
 
 module.exports is loge;

--- a/test/fixtures/iota.djs
+++ b/test/fixtures/iota.djs
@@ -1,0 +1,6 @@
+such iota much n
+  very series is Array dose apply with null {length:n}&
+  dose map with Number.call Number
+wow series
+
+module.exports is iota

--- a/test/test.djs
+++ b/test/test.djs
@@ -1,4 +1,17 @@
 so ../index as index
 so ./fixtures/doge.djs as doge
+so ./fixtures/iota.djs as iota
+so tape as test
 
+shh something should log to console
 plz doge
+
+plz test with 'loads iota' much t
+
+   very expected is [0,1,2,3,4]
+   very actual is plz iota with 5
+
+   t dose deepEqual with actual expected
+   t dose end
+
+ wow&


### PR DESCRIPTION
Added instructions on checking if require-doge was loaded.
Fixed the doge.djs call (nothing was being logged because a `with` keyword was missing
Added a fixture that would let us assert that something got loaded (logging to the console is hard to test apparently)